### PR TITLE
[Bug] Improve Error Handling For Invalid Accounts (SC-151203)

### DIFF
--- a/src/components/Error/ErrorFallback.tsx
+++ b/src/components/Error/ErrorFallback.tsx
@@ -1,10 +1,9 @@
-import get from "lodash/get";
-import { Stack } from "@deskpro/deskpro-ui";
 import { BasecampError } from "../../services/basecamp";
-import { DEFAULT_ERROR } from "../../constants";
 import { Container, ErrorBlock } from "../common";
-import type { FC } from "react";
+import { DEFAULT_ERROR } from "../../constants";
+import { Stack } from "@deskpro/deskpro-ui";
 import type { FallbackProps } from "react-error-boundary";
+import type { FC } from "react";
 
 type Props = Omit<FallbackProps, "error"> & {
   error: Error,
@@ -18,14 +17,18 @@ const ErrorFallback: FC<Props> = ({ error }) => {
   console.error(error);
 
   if (error instanceof BasecampError) {
-    message = get(error, ["data", "error"], DEFAULT_ERROR);
+    message = error.data?.error ?? DEFAULT_ERROR
+  } else if (error instanceof Error) {
+    message = error.message.trim() !== "" ? error.message : DEFAULT_ERROR
+  } else {
+    message = DEFAULT_ERROR
   }
 
   return (
     <Container>
       <ErrorBlock
         text={(
-          <Stack gap={6} vertical style={{padding: "8px"}}>
+          <Stack gap={6} vertical style={{ padding: "8px" }}>
             {message}
             {button}
           </Stack>

--- a/src/services/basecamp/baseRequest.ts
+++ b/src/services/basecamp/baseRequest.ts
@@ -40,6 +40,26 @@ const baseRequest: Request = async (client, {
 
   if (!pagination) {
     const res = await dpFetch(requestUrl, options);
+    // Provide a detailed error message if the user's account is inactive.
+    // Source: https://github.com/basecamp/bc3-api?tab=readme-ov-file#404-not-found
+    if (res.status === 404) {
+      const reason = res.headers.get("Reason");
+
+      if (reason === "Account Inactive") {
+        throw new BasecampError({
+          status: 404,
+          data: {
+            status: 404,
+            error: "Your Basecamp account is inactive. Please check your subscription or re-enable the account."
+          },
+        });
+      } else {
+        throw new BasecampError({
+          status: 404,
+          data: await res.json(),
+        });
+      }
+    }
 
     if (res.status < 200 || res.status > 399) {
       throw new BasecampError({


### PR DESCRIPTION
## Description
This PR improves the error message shown to the user when their account in invalid. The change follows [Basecamp's API documentation](https://github.com/basecamp/bc3-api?tab=readme-ov-file#404-not-found).

## Evidence

<img width="164" alt="image" src="https://github.com/user-attachments/assets/cd4b65ec-ef4e-4764-ba1d-4d649ccc42ad" />
