### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -88,7 +88,15 @@
       {
         "url": "https://launchpad.37signals.com/.*",
         "methods": ["GET", "POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "client_id": {
+            "querystring": ["client_id"]
+          },
+          "client_secret": {
+            "querystring": ["client_secret"]
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This pull request updates the `manifest.json` file to support automatic injection of `client_id` and `client_secret` settings into the querystring for requests to `https://launchpad.37signals.com/.*`. This enhancement improves configuration flexibility for authentication parameters.

Settings injection improvements:

* Added a `settingsInjection` object to the relevant endpoint configuration, enabling `client_id` and `client_secret` to be passed via querystring parameters.